### PR TITLE
Test for and reduce leakage in CT_EQUAL

### DIFF
--- a/src/__test__/specification-utils.test.ts
+++ b/src/__test__/specification-utils.test.ts
@@ -1,17 +1,20 @@
 // (c) 2021 Privacy Research, LLC https://privacyresearch.io,  GPL-v3-only: see LICENSE file.
-
+import crypto from 'crypto'
 import { expand_message_xmd } from '../ristretto255-sha512/hash'
 import {
     contextString,
+    CT_EQUAL,
     I2OSP,
     latin1ToBytes,
     makeDST,
     Nh,
+    numberArrayXOR,
     OPRFCiphersuite,
     OPRFMode,
     OS2IP,
     SPEC_ID,
 } from '../specification-utils'
+import { performance } from 'perf_hooks'
 
 describe('Test specification utilities', () => {
     test('string-binary conversion', () => {
@@ -43,6 +46,70 @@ describe('Test specification utilities', () => {
         expect(OS2IP(xos8)).toEqual(xi)
     })
 
+    test('CT_EQUAL', () => {
+        const equalPrefixLengths = [0, 16, 256, 4096, 8191]
+        const arrayLength = 8192
+        const baseArray = Uint8Array.from(crypto.randomBytes(arrayLength))
+        expect(CT_EQUAL(baseArray, baseArray)).toBe(true)
+
+        const numTests = 10000
+        const results: Record<number | string, number[]> = {
+            [0]: [],
+            [16]: [],
+            [256]: [],
+            [4096]: [],
+            [8191]: [],
+            total: [],
+        }
+        for (let i = 0; i < numTests; ++i) {
+            const suffixes = equalPrefixLengths.map((n) => Uint8Array.from(crypto.randomBytes(arrayLength - n)))
+            for (const suffix of suffixes) {
+                const testArray = Uint8Array.from([...baseArray.slice(0, arrayLength - suffix.length), ...suffix])
+                const other = Uint8Array.from(baseArray)
+                // make sure the arrays are different at least in the last byte
+                testArray[testArray.length - 1] = 255 - baseArray[testArray.length - 1]
+                const t1 = performance.now()
+                const shouldBeFalse = CT_EQUAL(testArray, other)
+                const t2 = performance.now()
+                const duration = t2 - t1
+                results.total.push(duration)
+                results[arrayLength - suffix.length].push(duration)
+                if (shouldBeFalse) {
+                    console.log({ i, suffix })
+                }
+                expect(shouldBeFalse).toBe(false)
+            }
+        }
+
+        // now do analysis
+        const totalStats = arrayStatistics(results.total)
+        for (const key of Object.keys(results)) {
+            const stats = arrayStatistics(results[key])
+            console.log({
+                key,
+                stats,
+                propVar: ((stats.mean - totalStats.mean) * Math.sqrt(numTests)) / stats.stddev,
+            })
+            expect((Math.abs(totalStats.mean - stats.mean) * Math.sqrt(numTests)) / stats.stddev).toBeLessThan(10)
+        }
+    })
+    test('CT_EQUAL bad input', () => {
+        expect(() => {
+            CT_EQUAL(Uint8Array.from([1, 2, 3]), Uint8Array.from([1]))
+        }).toThrow()
+    })
+
+    test('numberArrayXOR', () => {
+        const xor = numberArrayXOR([127, 255, 8], [8, 24, 8])
+        expect(xor).toEqual(Uint8Array.from([119, 231, 0]))
+    })
+
+    test('numberArrayXOR bad input', () => {
+        expect(() => {
+            numberArrayXOR(Uint8Array.from([1, 2, 3]), Uint8Array.from([1]))
+        }).toThrow()
+    })
+
     test('Reject expansion when too big', () => {
         const dst = makeDST('ExpansionTest-', contextString(OPRFMode.Base, OPRFCiphersuite.Ristretto255SHA512))
         expect(() => {
@@ -57,3 +124,25 @@ describe('Test specification utilities', () => {
         }).not.toThrow('Requested expanded length too large.')
     })
 })
+
+function arrayStatistics(arr: number[]) {
+    let sum = 0
+    let sumSquares = 0
+    let max = Number.MIN_VALUE
+    let min = Number.MAX_VALUE
+    for (const n of arr) {
+        sum += n
+        sumSquares += n * n
+        max = Math.max(n, max)
+        min = Math.min(n, min)
+    }
+    const mean = sum / arr.length
+    const variance = sumSquares / arr.length - mean * mean
+    return {
+        mean,
+        variance,
+        min,
+        max,
+        stddev: Math.sqrt(variance),
+    }
+}

--- a/src/specification-utils.ts
+++ b/src/specification-utils.ts
@@ -53,11 +53,11 @@ export function CT_EQUAL(a: Uint8Array, b: Uint8Array): boolean {
     if (a.length !== b.length) {
         throw new Error('Cannot compare arrays of different lengths.')
     }
-    let result = true
-    for (const i in a) {
-        result &&= a[i] === b[i]
+    let result = 1
+    for (let i = 0; i < a.length; ++i) {
+        result *= a[i] === b[i] ? 1 : 0
     }
-    return result
+    return result !== 0
 }
 
 export function makeDST(prefixString: string, contextString: Uint8Array): Uint8Array {


### PR DESCRIPTION
The CT_EQUAL function had a clear timing dependency on the size of the common prefix of two compared byte arrays. This pull request adds tests that detected this dependency and provides a new implementation with substantially better performance by this measure.