### PR TITLE
Add test for the `noble-ed25519` ciphersuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ const { evaluatedElements, proof } = serverContext.verifiableEvaluateBatch(blind
 const output = clientContext.verifiableFinalizeBatch(inputs, blinds, evaluatedElements, blindedElements, proof, info)
 ```
 
+## Implementing New Ciphersuites
+
+A good place to get started when developing a new ciphersuite for use with this library is the [Privacy Research
+`ciphersuites` repository](https://github.com/privacyresearchgroup/ciphersuites). There you will find
+
+- Type definitions for groups, scalars, and ciphersuites
+- Implementations of standard functions such as `I2OSP`, `OS2IP`, `CT_EQUAL`, and `expand_message_xmd`
+- Ciphersuite implementations, including `@privacyresearch/noble-restretto255-sha256`, an implementation
+  of the `OPRF(Ristretto255, SHA256)` ciphersuite based on [`noble-ed25519`](https://github.com/paulmillr/noble-ed25519).
+  To see this ciphersuite in use, look at this [unit test](https://github.com/privacyresearchgroup/oprf-ts/blob/main/src/__test__/rfc-ristretto-batch-verifiable-vectors-noble-ciphersuite.test.ts).
+
+  _This implementation uses the native `bigint` and is much faster than the `JSBI` implementation described above. If `bigint`s are available and acceptable for your application, `nobe-ed25519` is preferred._
+
 ## License
 
 (c) 2021 Privacy Research, LLC [(https://privacyresearch.io)](https://privacyresearch.io), see LICENSE file.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "hash.js": "^1.1.7"
   },
   "devDependencies": {
+    "@privacyresearch/noble-ciphersuite-r255s256": "^0.0.1",
     "@types/base64-js": "^1.3.0",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^4.25.0",

--- a/src/__test__/rfc-ristretto-batch-verifiable-vectors-noble-ciphersuite.test.ts
+++ b/src/__test__/rfc-ristretto-batch-verifiable-vectors-noble-ciphersuite.test.ts
@@ -1,0 +1,196 @@
+// (c) 2021 Privacy Research, LLC https://privacyresearch.io,  GPL-v3-only: see LICENSE file.
+
+import { hexToBytes } from '@privacyresearch/ed25519-ts/lib/serialization'
+import { VerifiableClientContextImpl } from '../contexts/verifiable-client-context'
+import { VerifiableServerContextImpl } from '../contexts/verifiable-server-context'
+import { ristretto255SHA512Ciphersuite } from '@privacyresearch/noble-ciphersuite-r255s256'
+import { numberArrayXOR, OPRFMode } from '../specification-utils'
+
+const ciphersuite = ristretto255SHA512Ciphersuite(OPRFMode.Verified)
+
+describe('Ristretto RFC tests', () => {
+    test('A.1.2 test key derivation', () => {
+        //     seed = a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3
+        //     skSm = ac37d5850510299406ea8eb8fa226a7bfc2467a4b070d6c7bf667948b9600b00
+        //     pkSm = 0c0254e22063cae3e1bae02fb6fa20882664a117c0278eda6bda3372c0dd9860
+        const seed = hexToBytes('a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3')
+        const skSm = hexToBytes('ac37d5850510299406ea8eb8fa226a7bfc2467a4b070d6c7bf667948b9600b00')
+        const pkSm = hexToBytes('0c0254e22063cae3e1bae02fb6fa20882664a117c0278eda6bda3372c0dd9860')
+
+        expect(seed.length).toEqual(32)
+        const { skS, pkS } = ciphersuite.GG.deriveKeyPair(seed)
+        const skSBytes = ciphersuite.GG.serializeScalar(skS)
+        const pkSBytes = ciphersuite.GG.serializeElement(pkS)
+        expect(skSBytes.length).toEqual(32)
+        expect(pkSBytes.length).toEqual(32)
+
+        expect(skSBytes).toEqual(skSm)
+        expect(pkSBytes).toEqual(pkSm)
+    })
+
+    // Input = 00,5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a
+    // Info = 7465737420696e666f
+    // Blind = 80513e77795feeec6d2c450589b0e1b178febd5c193a9fcba0d27f0a06e0d50f,
+    //     533c2e6d91c934f919ac218973be55ba0d7b234160a0d4cf3bddafbda99e2e0c
+    // BlindedElement = c24645d6378a4a86ec4682a8d86f368b1e7db870fd709a45102492bcdc17e904,
+    //     0e5ec78f839a8b6e86999bc180602690a4daae57bf5d7f827f3d402f56cc6c51
+    // EvaluationElement = 3afe48eab00493eb1b073e95f57a456cde9aefe463dd1e6d0144bf6e99ce411c,
+    //     daaf9421318fd2c7fcdf369cb348748cf4dd177cce30ee4d13ceb1644b85b653
+    // Proof = 601381ecbe127ada04c057b8b1fc21d912f71e49252780dd0d0ac768b233ce035f9b489a994c1d14b92d603ebcffee4f5cfadc953f69bb62648c6e662613ae00
+    // ProofRandomScalar = 3af5aec325791592eee4a8860522f8444c8e71ac33af5186a9706137886dce08
+    // Output = 4b2ff4c984985829c3cd9d90c255cdc0d6b61c4c0aafa9215769d51cf7deb01472ba945928a8305e010f12b7dcc75a9dc2460439e6297d57dc2ce7ca0abaae1a,
+    //     fe1fb7fa49c37dc7cd31d64859b4a2e6ae0cef294f2764e6f12f7d809f218047d1fde147cf69807b8971fb2c316eb572be2b5bf491813bfec0a20668d6d07b0b
+
+    const vectorsA123 = {
+        seed: hexToBytes('a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3'),
+        skS: hexToBytes('ac37d5850510299406ea8eb8fa226a7bfc2467a4b070d6c7bf667948b9600b00'),
+        pkS: hexToBytes('0c0254e22063cae3e1bae02fb6fa20882664a117c0278eda6bda3372c0dd9860'),
+        input: [hexToBytes('00'), hexToBytes('5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a')],
+        info: hexToBytes('7465737420696e666f'),
+        blind: [
+            hexToBytes('80513e77795feeec6d2c450589b0e1b178febd5c193a9fcba0d27f0a06e0d50f'),
+            hexToBytes('533c2e6d91c934f919ac218973be55ba0d7b234160a0d4cf3bddafbda99e2e0c'),
+        ],
+        blindedElement: [
+            hexToBytes('c24645d6378a4a86ec4682a8d86f368b1e7db870fd709a45102492bcdc17e904'),
+            hexToBytes('0e5ec78f839a8b6e86999bc180602690a4daae57bf5d7f827f3d402f56cc6c51'),
+        ],
+        evaluatedElement: [
+            hexToBytes('3afe48eab00493eb1b073e95f57a456cde9aefe463dd1e6d0144bf6e99ce411c'),
+            hexToBytes('daaf9421318fd2c7fcdf369cb348748cf4dd177cce30ee4d13ceb1644b85b653'),
+        ],
+        proof: hexToBytes(
+            '601381ecbe127ada04c057b8b1fc21d912f71e49252780dd0d0ac768b233ce035f9b489a994c1d14b92d603ebcffee4f5cfadc953f69bb62648c6e662613ae00'
+        ),
+        proofRandomScalar: hexToBytes('3af5aec325791592eee4a8860522f8444c8e71ac33af5186a9706137886dce08'),
+        output: [
+            hexToBytes(
+                '4b2ff4c984985829c3cd9d90c255cdc0d6b61c4c0aafa9215769d51cf7deb01472ba945928a8305e010f12b7dcc75a9dc2460439e6297d57dc2ce7ca0abaae1a'
+            ),
+            hexToBytes(
+                'fe1fb7fa49c37dc7cd31d64859b4a2e6ae0cef294f2764e6f12f7d809f218047d1fde147cf69807b8971fb2c316eb572be2b5bf491813bfec0a20668d6d07b0b'
+            ),
+        ],
+    }
+    type VerifiableBatchSize2Vector = typeof vectorsA123
+
+    function verifiableServerContextBatchSize1Evaluate(v: VerifiableBatchSize2Vector) {
+        const { info, blindedElement, seed } = v
+
+        const vEvaluatedElement = v.evaluatedElement
+
+        const { skS } = ciphersuite.GG.deriveKeyPair(seed)
+
+        const serverContext = new VerifiableServerContextImpl(ciphersuite, skS)
+
+        const evaluatedElement = serverContext.evaluate(blindedElement[0], info)
+        expect(evaluatedElement).toEqual(vEvaluatedElement[0])
+    }
+
+    function verifiableClientContextFinalize(v: VerifiableBatchSize2Vector) {
+        const { input, info, blind, evaluatedElement } = v
+        const vOutput = v.output
+
+        const pkS = ciphersuite.GG.deserializeElement(v.pkS)
+
+        const clientContext = new VerifiableClientContextImpl(ciphersuite, pkS)
+
+        const output = clientContext.finalize(input[0], blind[0], evaluatedElement[0], info)
+        expect(output).toEqual(vOutput[0])
+    }
+
+    function verifiableModeFullProtocol(v: VerifiableBatchSize2Vector) {
+        const { seed, input, info } = v
+
+        const vOutput = v.output
+
+        const { skS, pkS } = ciphersuite.GG.deriveKeyPair(seed)
+
+        const clientContext = new VerifiableClientContextImpl(ciphersuite, pkS)
+        const serverContext = new VerifiableServerContextImpl(ciphersuite, skS)
+
+        const blindResults = input.map((i) => clientContext.blind(i))
+        const blinds = blindResults.map((r) => r.blind)
+        const blindedElements = blindResults.map((r) => r.blindedElement)
+
+        const evalResults = serverContext.verifiableEvaluateBatch(blindedElements, info)
+
+        const output = clientContext.verifiableFinalizeBatch(
+            input,
+            blinds,
+            evalResults.evaluatedElements,
+            blindedElements,
+            evalResults.proof,
+            info
+        )
+        expect(output).toEqual(vOutput)
+    }
+
+    function verifiableModeFullEvaluate(v: VerifiableBatchSize2Vector) {
+        const { seed, input, info } = v
+
+        const vOutput = v.output
+
+        const { skS } = ciphersuite.GG.deriveKeyPair(seed)
+        const serverContext = new VerifiableServerContextImpl(ciphersuite, skS)
+
+        const output = serverContext.fullEvaluate(input[0], info)
+        expect(output).toEqual(vOutput[0])
+    }
+
+    function verifiableModeVerifyFinalize(v: VerifiableBatchSize2Vector) {
+        const { seed, input, info, output } = v
+        const { skS } = ciphersuite.GG.deriveKeyPair(seed)
+        const serverContext = new VerifiableServerContextImpl(ciphersuite, skS)
+
+        const valid = serverContext.verifyFinalize(input[0], output[0], info)
+        expect(valid).toBe(true)
+    }
+
+    function verifiableClientContextAcceptProof(v: VerifiableBatchSize2Vector) {
+        const { seed, input, info, blind, evaluatedElement, blindedElement } = v
+
+        expect(v.proof.length).toEqual(64)
+        const proof = { c: v.proof.slice(0, 32), s: v.proof.slice(32, 64) }
+        const mask = [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+        const badProof = { c: proof.c, s: numberArrayXOR(proof.s, mask) }
+
+        const { pkS } = ciphersuite.GG.deriveKeyPair(seed)
+        const badPKS = ciphersuite.GG.add(ciphersuite.GG.G, pkS)
+        const clientContext = new VerifiableClientContextImpl(ciphersuite, pkS)
+        const badPKClientContext = new VerifiableClientContextImpl(ciphersuite, badPKS)
+        expect(() => {
+            clientContext.verifiableFinalizeBatch(input, blind, evaluatedElement, blindedElement, proof, info)
+        }).not.toThrow()
+        expect(() => {
+            clientContext.verifiableFinalizeBatch(input, blind, evaluatedElement, blindedElement, badProof, info)
+        }).toThrow()
+        expect(() => {
+            badPKClientContext.verifiableFinalizeBatch(input, blind, evaluatedElement, blindedElement, badProof, info)
+        }).toThrow()
+    }
+
+    test('A.1.2.3 Test Vector 2 Batch Size 2: ServerVerifiableServerContextContext::evaluate', () => {
+        verifiableServerContextBatchSize1Evaluate(vectorsA123)
+    })
+
+    test('A.1.2.3 Test Vector 2 Batch Size 2: ClientContext::finalize', () => {
+        verifiableClientContextFinalize(vectorsA123)
+    })
+
+    test('A.1.2.3 Test Vector 2 Batch Size 2: Full run with random blinds', () => {
+        verifiableModeFullProtocol(vectorsA123)
+    })
+
+    test('A.1.2.3 Test Vector 2 Batch Size 2: VerifiableServerContext::FullEvaluate', () => {
+        verifiableModeFullEvaluate(vectorsA123)
+    })
+
+    test('A.1.2.3 Test Vector 2 Batch Size 2: VerifiableServerContext::VerifyFinalize', () => {
+        verifiableModeVerifyFinalize(vectorsA123)
+    })
+
+    test('A.1.2.3 Test Vector 2 Batch Size 2: Test verification', () => {
+        verifiableClientContextAcceptProof(vectorsA123)
+    })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,10 +543,24 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@privacyresearch/ciphersuite-shared@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@privacyresearch/ciphersuite-shared/-/ciphersuite-shared-0.0.3.tgz#3fe6bdb5b13233b6a1515d9c1a6a75132dfd3aa1"
+  integrity sha512-Z34+TpzNRf/4lT+l2IuyoTm4zauIioDfOEMWE0R6tXw2Bbtnbu3lGv80ZsMiB+WyKbfPiMD6Hywhx/NUEkl+uw==
+
 "@privacyresearch/ed25519-ts@^0.0.1-rc":
   version "0.0.1-rc"
   resolved "https://registry.yarnpkg.com/@privacyresearch/ed25519-ts/-/ed25519-ts-0.0.1-rc.tgz#7a9adbd0fe248ff19979bc4de10d473f8ecad723"
   integrity sha512-Xv+yh373/IhvQ7Zc3NLNM4WQ2JWfuUrSdlijf8Xmfr823NfFu58ToXE9SzC1osYsYTqtBHDV9ksmN8aF7ONnsQ==
+
+"@privacyresearch/noble-ciphersuite-r255s256@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@privacyresearch/noble-ciphersuite-r255s256/-/noble-ciphersuite-r255s256-0.0.1.tgz#1bc60d7b33f121c771d2f48e4f0bb221373ad965"
+  integrity sha512-iHav6EObWo/Ch/KznzepUJyKsuaNozsPCMYuko1yi2HKQkadpEUrx8tGzT5Wf70FOoDBzYRRFZcm0RhB6qCoSw==
+  dependencies:
+    "@privacyresearch/ciphersuite-shared" "^0.0.3"
+    hash.js "^1.1.7"
+    noble-ed25519 "^1.2.6"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -2437,6 +2451,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+noble-ed25519@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/noble-ed25519/-/noble-ed25519-1.2.6.tgz#a55b75c61da000498abb43ffd81caaa370bfed22"
+  integrity sha512-zfnWqg9FVMp8CnzUpAjbt1nDXpDjCvxYiCXdnW1mY8zQHw/6twUlkFm14VPdojVzc0kcd+i9zT79+26GcNbsuQ==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Add advice for writing new ciphersuites in the README and demonstrate it with a test of the external ciphersuite `@privacyresearch/noble-restretto255-sha256`.